### PR TITLE
Fix link to company listing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The initial design of ruby.sg was done by @winstonyw who is not a designer by tr
 
 ## Singapore Companies using Ruby
 
-You can add your company to [ruby.sg](http://ruby.sg#companies) by editing [companies.rb](app/models/companies.rb).
+You can add your company to [ruby.sg](http://ruby.sg#companies) by editing [company.rb](https://github.com/rubysg/rubysg-reboot/blob/master/app/models/company.rb).
 
 Instructions as follows:
 


### PR DESCRIPTION
The original link was devoid of branching information, so it takes you to a 404.
A hardcoded link works better because it doesn't mess up on the branch information
in the url.