### PR TITLE
Refactor companies image markup

### DIFF
--- a/app/assets/stylesheets/companies.scss
+++ b/app/assets/stylesheets/companies.scss
@@ -8,32 +8,29 @@
   padding: 25px;
   position: relative;
 
-  @media (max-width: 768px) {
-    text-align: center;
-  }
-
   .website {
     a {
       color: inherit;
     }
   }
 
-  .company-logo {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100px;
+  .media {
+    margin-top: 0;
+
+    .media-left {
+      padding-right: 30px;
+    }
   }
 
-  .company-logo img {
-    margin-bottom: 20px;
-    max-width: 80%;
-    max-height: 100px;
-    object-fit: contain;
+  .company-logo {
+    $logo-size: 100px;
 
-    @media (max-width: 768px) {
-      max-width: 40%;
-    }
+    background-color: transparent;
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
+    height: $logo-size;
+    width: $logo-size;
   }
 
   .company-hiring {
@@ -89,5 +86,10 @@
     color: $theme-gray;
     height: 2em;
     margin-bottom: 15px;
+
+    @media (max-width: 768px) {
+      height: auto;
+      margin-bottom: 5px;
+    }
   }
 }

--- a/app/views/application/companies.html.slim
+++ b/app/views/application/companies.html.slim
@@ -3,18 +3,16 @@
     h2.section-heading Singapore Companies using Ruby
     .row
       - @companies.each do |company|
-        .col-sm-6.company-wrapper
+        .col-md-6.company-wrapper
           .company
             - if company.hiring_url.present?
               = link_to company.hiring_url, class: 'company-hiring', target: '_blank'
                 i.fa.fa-2x.fa-briefcase.hiring-icon
-            .row
-              .col-sm-3
-                .website
-                  = link_to company.website, target: '_blank' do
-                    .company-logo
-                      = image_tag company.logo_url
-              .col-sm-9
+            .media
+              .media-left
+                = link_to company.website, target: '_blank' do
+                  .media-object.company-logo style='background-image: url(#{company.logo_url})'
+              .media-body
                 .company-name
                   = company.name
                 .address-contact.small
@@ -22,4 +20,3 @@
                     = company.address
                   .contact.text-muted
                     = company.email
-              .col-sm-2.col-sm-offset-1

--- a/config/initializers/companies.yml
+++ b/config/initializers/companies.yml
@@ -172,7 +172,7 @@
 -
   name:       'Aureso'
   website:    'http://www.aureso.com'
-  logo_url:   'https://scontent-sin1-1.xx.fbcdn.net/v/t1.0-9/13427793_534811873395141_8229663433544113851_n.png?oh=d7762469d33928c843dee88c590fc0a6&oe=57C7324F'
+  logo_url:   'https://s3.postimg.org/blelc6iqb/13427793_534811873395141_8229663433544113851_n.png'
   address:    '59 Kampong Bahru Road, #02-03, Singapore 169367'
   hiring_url: 'http://www.aureso.com/career'
   email:      'team@aureso.com'


### PR DESCRIPTION
Changed to CSS background approach of rendering the image. This brings the benefit of not showing the broken img icon if the img link is broken.

This partially fixes #131. I did not use a placeholder image, instead the image will be empty as mentioned above. I think it's more elegant than using JS to listen for error events and I'm not really keen to add N event listeners for N images.

Lastly I uploaded Aureso's logo to some free img hosting site and fixed the broken img path problem.