### PR TITLE
Change RDRC registration link to a link to the talks

### DIFF
--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -29,8 +29,8 @@
         .section
           h3.section-heading.sub.heading-line RedDotRubyConf
           p Join us for South East Asia's largest Ruby conference. Two whole days, jam packed with fun and talks. Hear Matz and other great speakers from all over the world talk about the future of Ruby.
-          a.btn.btn-lg.btn-primary href='http://www.reddotrubyconf.com' target='_blank'
-            span Register Now
+          a.btn.btn-lg.btn-primary href='https://engineers.sg/conference/reddotrubyconf2017' target='_blank'
+            span Watch The Talks
 
 .section.section-gray#join-us
   .container-fluid


### PR DESCRIPTION
Since you can no longer register for RDRC, changed to a link to the talks over at Engineers. 🙂 