### PR TITLE
Fix font awesome breakage

### DIFF
--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -1,6 +1,6 @@
 .container
   .section
-    h2.section-heading Our Community Supporters! Thank you! #{icon :heart}
+    h2.section-heading Our Community Supporters! Thank you! #{icon :fas, :heart}
     p.text-center These companies have recently sponsored RubySG meetups and/or provided speakers
     .row
       = render @supporter_companies, partial: 'company'

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CompaniesController do
   describe '#index' do
+    render_views
+
     def do_request
       get :index
     end


### PR DESCRIPTION
Font Awesome updated their view helper signature. This caused the companies page to break. This change does:

- Do `render_views` in the companies controller spec, to cover the error.
- Update the FA call on the companies page.