### PR TITLE
Fix the social icons on the front page not displaying

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -154,7 +154,7 @@
     }
   }
 
-  i.fa {
+  i.fab {
     margin-right: 2rem;
   }
 }

--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -37,13 +37,13 @@
     h3.section-heading.heading-line Join Us
     .row.text-center
       a.col-sm-4.join-us-col.join-us-fb href='https://www.facebook.com/groups/singaporerubybrigade' target='_blank'
-        i.fa.fa-lg.fa-facebook
+        = icon(:fab, :facebook, class: "fa-lg")
         span Facebook
       a.col-sm-4.join-us-col.join-us-google href='https://groups.google.com/forum/?fromgroups#!forum/singapore-rb' target='_blank'
-        i.fa.fa-lg.fa-google
+        = icon(:fab, :google, class: "fa-lg")
         span Google Group
       a.col-sm-4.join-us-col.join-us-github href='https://github.com/rubysg' target='_blank'
-        i.fa.fa-lg.fa-github
+        = icon(:fab, :github, class: "fa-lg")
         span GitHub
 
 .section#chat-with-us


### PR DESCRIPTION
### What's the problem?

Social icons on the front page are not displaying correctly. Screenshot:

<img width="1066" alt="screenshot 2018-11-15 at 15 19 11" src="https://user-images.githubusercontent.com/5259935/48537921-f6c81100-e8ed-11e8-9a07-27956e5cc7dc.png">

### Why was this happening?

We have upgraded Font Awesome, and in version 5 and above, the icons are namespaced. Instead of `fa`, we need to use `fab` for brand icons.

### How does this fix it?

Changed to use the `#icon` helper, and added the right prefix. Screenshot:

<img width="1232" alt="screenshot 2018-11-15 at 15 45 26" src="https://user-images.githubusercontent.com/5259935/48537939-08a9b400-e8ee-11e8-8fd7-c0ca83e6cca2.png">
