### PR TITLE
Fix broken telegram group link

### DIFF
--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -57,7 +57,7 @@
         = rubysg_telegram_qr_code_svg
 
         p
-          strong Invite yourself to our <a href="https://t.me/joinchat/BPfX501idx5NSmdANkOrtg" target="_blank">Telegram group</a>
+          strong Invite yourself to our <a href="https://t.me/joinchat/TWJ3HtLeJF81EweA" target="_blank">Telegram group</a>
 
 .section.section-black#companies
   .container


### PR DESCRIPTION
- Fix broken telegram group link on landing page
- Address issue: https://github.com/rubysg/rubysg-reboot/issues/318