### PR TITLE
make /companies more relevant 

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -10,8 +10,7 @@ class Company < FrozenRecord::Base
       .select(&:supporter?)
       .sort_by do |company|
         [
-          -company.contribution_count,
-          Date.today - Date.strptime(company.updated_on, "%Y-%m-%d")
+          Date.today - Date.strptime(company.updated_on, "%Y-%m-%d"),
         ]
       end
   end

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -8,3 +8,7 @@
     h2.section-heading More Companies Using Ruby
     .row
       = render @other_companies, partial: 'company'
+    p.text-center
+      ' More Ruby jobs in Singapore
+      a[href="https://www.nodeflair.com/jobs?query=&page=1&tech_stacks%5B%5D=Ruby" target="_blank"] here
+      '!

--- a/db/data/companies.yml
+++ b/db/data/companies.yml
@@ -294,7 +294,7 @@
   address:    '71 Robinson Road #13-155, Singapore 068895'
   hiring_url: 'https://www.shopify.com/careers'
   email:      'winston.teo@shopify.com'
-  updated_on: '2018-09-01'
+  updated_on: '2021-08-19'
   contribution_count: 4
 - name:       'Black Tangent'
   website:    'https://blacktangent.com'
@@ -318,5 +318,5 @@
   address:    '71 Ayer Rajah Crescent, #07-22 Singapore 139951'
   hiring_url: 'https://www.nodeflair.com/careers'
   email:      'hello@nodeflair.com'
-  updated_on: '2021-04-10'
-  contribution_count: 0
+  updated_on: '2021-08-19'
+  contribution_count: 1

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe Company do
         end
       end
 
-      it "companies are sorted by contribution_count :desc, then updated_on :desc" do
-        expect(companies[0].name).to eq "CCompany"
-        expect(companies[1].name).to eq "DCompany"
-        expect(companies[2].name).to eq "BCompany"
+      it "companies are sorted by updated_on :desc" do
+        expect(companies[0].name).to eq "DCompany"
+        expect(companies[1].name).to eq "BCompany"
+        expect(companies[2].name).to eq "CCompany"
       end
     end
 


### PR DESCRIPTION
I find that the list of companies a little outdated. So I want to

1. feature recent companies more
2. keep contributed companies as a token of appreciation. let the name live on forever! 
3. include a nodeflair link that filters all the Ruby jobs out there so that people know where to find Ruby jobs. 
    https://www.nodeflair.com/jobs?query=&page=1&tech_stacks%5B%5D=Ruby
    <img width="542" alt="Screenshot 2021-08-17 at 12 14 36 AM" src="https://user-images.githubusercontent.com/10722197/129595486-0dd26e72-75e5-40d5-9a59-0bd3fe850008.png">
