### PR TITLE
A basic form creation and submission framework

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class FormsController < ApplicationController
+  def show
+    @form = find_form_klass(params[:form_type]).new
+
+  rescue NameError
+    redirect_to "/404"
+  end
+
+  def create
+    @form = find_form_klass(form_params.require(:form_type)).new(form_params)
+
+    if @form.submit
+      redirect_to :root
+    else
+      render :show
+    end
+
+  rescue NameError
+    redirect_to "/404"
+  end
+
+  private
+
+  def form_params
+    params.require(:form)
+  end
+
+  def find_form_klass(form_type)
+    "Feedback::#{form_type.camelcase}".constantize
+  end
+end

--- a/app/forms/feedback/behind_the_gems2.rb
+++ b/app/forms/feedback/behind_the_gems2.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Feedback
+  class BehindTheGems2 < FeedbackForm
+    title "Behind the Gems 2 :: 6"
+
+    questions [
+      {
+        key: :rating,
+        question: "How would you rate today's meetup?",
+        options: [1, 2, 3, 4, 5],
+        required: true
+      },
+      {
+        key: :feedback,
+        question: "Any other feedback?"
+      },
+    ]
+  end
+end

--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class FeedbackForm
+  include ActiveModel::Model
+
+  class WrongQuestionFormatError < StandardError; end;
+
+  class << self
+    def model_name
+      ActiveModel::Name.new(self, nil, 'Form')
+    end
+
+    private
+
+    def title(title_name)
+      class_eval %Q{
+        def title
+          "#{title_name}"
+        end
+      }
+    end
+
+    def questions(qns = [])
+      qns.each do |qn|
+        raise(WrongQuestionFormatError, "Question must contain key") unless qn.include?(:key)
+        raise(WrongQuestionFormatError, "Question must contain question") unless qn.include?(:question)
+
+        class_eval %Q{
+          attr_accessor :#{qn[:key]}
+          #{ qn[:required] == true ? "validates :#{qn[:key]}, presence: true" : "" }
+        }
+      end
+
+      class_eval %Q{
+        def questions
+          #{qns}
+        end
+      }
+    end
+  end
+
+  attr_reader :form_type
+
+  title "Feedback Form"
+  questions []
+
+  def initialize(params = ActionController::Parameters.new)
+    @form_type = self.class.name.demodulize
+    super(params.permit(question_keys))
+  end
+
+  def submit
+    return false unless valid?
+
+    FormResponse.new({
+      form_type: form_type,
+      response: question_keys.each_with_object({}) { |key, obj| obj[key] = send(key) }
+    }).save
+  end
+
+  private
+
+  def question_keys
+    questions.map { |q| q[:key] }
+  end
+end

--- a/app/models/form_response.rb
+++ b/app/models/form_response.rb
@@ -1,0 +1,4 @@
+class FormResponse < ApplicationRecord
+  validates :form_type, presence: true
+  validates :response, presence: true
+end

--- a/app/views/forms/show.html.slim
+++ b/app/views/forms/show.html.slim
@@ -1,0 +1,46 @@
+.container
+  .section
+    h1 = @form.title
+
+    = form_with(id: :form, model: @form) do |form|
+      = form.hidden_field :form_type, value: @form.form_type
+
+      - @form.questions.each do |question|
+        - if question[:options].is_a?(Array)
+          = field_set_tag nil, "cf-questions" => question[:question] do
+            - question[:options].each do |option|
+              = form.radio_button question[:key], option, required: question[:required], "cf-label" => option
+
+        - else
+          = form.text_field question[:key], required: question[:required], "cf-questions" => question[:question]
+
+    div[id="cf-context" role="cf-context" cf-context=true]
+
+script[type="text/javascript" src="https://cdn.jsdelivr.net/gh/space10-community/conversational-form@1.0.1/dist/conversational-form.min.js" crossorigin=true]
+
+css:
+  /*
+    TODO: Move this into asset pipeline. For some reason putting styles in
+      base.scss does not get picked up.
+  */
+  html {
+    scroll-behavior: smooth;
+  }
+
+  #cf-context {
+    width: 100%;
+    height: 500px;
+  }
+
+  #form {
+    position: absolute;
+    height: 0px;
+    visibility: hidden;
+  }
+
+javascript:
+  var conversationalForm = window.cf.ConversationalForm.startTheConversation({
+    formEl: document.getElementById("form"),
+    context: document.getElementById("cf-context"),
+    theme: 'red'
+  })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   resources :companies, only: [:index]
   resources :invitations, only: [:create]
+  resources :forms, param: :form_type, only: [:show, :create]
 
   namespace :api do
     post "ruby_sg_bot/webhook", to: "ruby_sg_bot#webhook"

--- a/db/migrate/20210912145012_create_form_responses.rb
+++ b/db/migrate/20210912145012_create_form_responses.rb
@@ -1,0 +1,10 @@
+class CreateFormResponses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :form_responses do |t|
+      t.string :form_type
+      t.json :response
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,21 +2,28 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200606045806) do
+ActiveRecord::Schema.define(version: 2021_09_12_145012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "form_responses", force: :cascade do |t|
+    t.string "form_type"
+    t.json "response"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "ruby_sg_bot_subscribers", force: :cascade do |t|
-    t.string   "chat_id"
+    t.string "chat_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe FormsController do
+
+  describe "#show" do
+    it "redirects to /404 if feedback form does not exist" do
+      get :show, params: { form_type: "non_existent_form" }
+
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to("/404")
+    end
+
+    it "renders if feedback form exists" do
+      get :show, params: { form_type: "behind_the_gems2" }
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "#create" do
+    it "redirects to /404 if form does not exist" do
+      post :create, params: { form: { form_type: "non_existent_form" } }
+
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to("/404")
+    end
+
+    it "renders :show if form submission is unsuccessful" do
+      post :create, params: { form: { form_type: "behind_the_gems2" } }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "redirects to root if form submission is successful" do
+      post :create, params: { form: { form_type: "behind_the_gems2", rating: 1, feedback: "none" } }
+
+      expect(response).to have_http_status(:redirect)
+      expect(response).to redirect_to(root_url)
+    end
+  end
+end

--- a/spec/forms/feedback/behind_the_gems2_spec.rb
+++ b/spec/forms/feedback/behind_the_gems2_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Feedback::BehindTheGems2 do
+  subject { Feedback::BehindTheGems2.new }
+
+  it "#title returns correct title" do
+    expect(subject.title).to eq "Behind the Gems 2 :: 6"
+  end
+
+  it "#questions return list of questions" do
+    expect(subject.questions.count).to eq 2
+    expect(subject.questions.first).to eq({
+      key: :rating,
+      question: "How would you rate today's meetup?",
+      options: [1, 2, 3, 4, 5],
+      required: true
+    })
+    expect(subject.questions.second).to eq({
+      key: :feedback,
+      question: "Any other feedback?"
+    })
+  end
+
+  it "#submit return false if there are missing answers" do
+    expect(subject.submit).to eq false
+  end
+
+  it "#submit does not create a FormResponse if not all required answers are provided" do
+    expect {
+      subject.submit
+    }.to change { FormResponse.count }.by(0)
+  end
+
+  it "#submit return true if all required answers are provided" do
+    expect(
+      Feedback::BehindTheGems2.new(ActionController::Parameters.new({ rating: 1 })).submit
+    ).to eq true
+  end
+
+  it "#submit creates a FormResponse if all required answers are provided" do
+    form = Feedback::BehindTheGems2.new(ActionController::Parameters.new({ rating: 1 }))
+
+    expect { form.submit }.to change { FormResponse.count }.by(1)
+    expect(FormResponse.last.form_type).to eq form.form_type
+    expect(FormResponse.last.response).to eq({ "rating" => 1, "feedback" => nil })
+  end
+end

--- a/spec/forms/feedback_form_spec.rb
+++ b/spec/forms/feedback_form_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe FeedbackForm do
+  subject { FeedbackForm.new }
+  let(:class_object) { subject.class }
+  let(:dummy_questions) do
+    [
+      {
+        key: :rating,
+        question: "How would you rate this form?",
+        required: true,
+      },
+      {
+        key: :feedback,
+        question: "Any other feedback?",
+      }
+    ]
+  end
+
+  it "#title returns default title" do
+    expect(subject.title).to eq "Feedback Form"
+  end
+
+  it "#questions return empty array" do
+    expect(subject.questions).to eq []
+  end
+
+  it "#form_type is the class name without namespace" do
+    expect(subject.form_type).to eq "FeedbackForm"
+    expect(Feedback::BehindTheGems2.new.form_type).to eq "BehindTheGems2"
+  end
+
+  describe "Meta programming methods" do
+    after(:each) do
+      class_object.send(:title, "Feedback Form")
+      class_object.send(:questions, [])
+    end
+
+    it ".title overrides #title for form" do
+      class_object.send(:title, "A dummy form")
+
+      expect(subject.title).to eq "A dummy form"
+    end
+
+    it ".questions overrides #questions for form" do
+      class_object.send(:questions, dummy_questions)
+
+      expect(subject.questions).to be_an(Array)
+      expect(subject.questions.first).to eq({ key: :rating, question: "How would you rate this form?", required: true })
+      expect(subject.questions.second).to eq({ key: :feedback, question: "Any other feedback?" })
+    end
+
+    it ".questions set attr_accessor for each key in questions list" do
+      class_object.send(:questions, dummy_questions)
+
+      subject.rating = 10
+      expect(subject.rating).to eq 10
+
+      subject.feedback = "This is a great form!"
+      expect(subject.feedback).to eq "This is a great form!"
+    end
+
+    it ".questions set presence validator for each required key in questions list" do
+      class_object.send(:questions, dummy_questions)
+
+      subject.rating = nil
+      subject.feedback = nil
+      subject.valid?
+
+      expect(subject.errors.to_hash).to include(:rating)
+      expect(subject.errors.to_hash).not_to include(:feedback)
+    end
+
+    it ".questions does not set presence validator for non-required key in questions list" do
+      class_object.send(:questions, dummy_questions)
+
+      subject.rating = 1
+      subject.feedback = nil
+      subject.valid?
+
+      expect(subject.errors.to_hash).not_to include(:rating)
+      expect(subject.errors.to_hash).not_to include(:feedback)
+    end
+
+    it ".questions raises WrongQuestionFormatError if any question is missing key" do
+      expect {
+        FeedbackForm.send(:questions, [{ irrelevant_key: "irrelevant value" }])
+      }.to raise_error FeedbackForm::WrongQuestionFormatError
+    end
+
+    it ".questions raises WrongQuestionFormatError if any question is missing question" do
+      expect {
+        FeedbackForm.send(:questions, [{ key: "key" }])
+      }.to raise_error FeedbackForm::WrongQuestionFormatError
+    end
+  end
+end

--- a/spec/models/form_response_spec.rb
+++ b/spec/models/form_response_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe FormResponse, type: :model do
+  context 'validations' do
+    it { is_expected.to validate_presence_of :form_type }
+    it { is_expected.to validate_presence_of :response }
+  end
+end


### PR DESCRIPTION
I want to create forms on RubySG so that I can collect feedbacks from meetup participants. 


The requirements are: 
1. No admin page to CRUD forms. Ruby.sg currently does not have admin pages and I do not want to set a precedence for it.
2. I want to be able to have multiple forms and collect feedbacks for each. This is so that I can create one feedback form for each event (eg. meetup) 

## Approach

1. I want to be able to create forms with code. 
    ```ruby 
    # this is pseudo code
    class ThisIsAForm
      title "Meetup - Jan 2021"

      questions [{
        question: "How would you rate today's meetup?"
        ...
      }, {
        question: "Any suggestions to make this better?"
        ...
      }]
    end
    ```
2. A url should be immediately available for the form so that I can answer the question
    ```
    https://ruby.sg/forms/this_is_a_form
    ```

## How did I do it? 

The implementation consists of 4 parts:

#### 1. FeedbackForm objects

The implementation of FeedbackForm objects is heavily influenced by Form Object Pattern and Meta-Programming style in RoR. Every form object inherits the `FeedbackForm` class and is namespace with `FeedbackForm` so as not to confuse with general usage Form Object Pattern in the future. `feedback_form.rb` provides the template for all feedback forms so that they all can share the same view code. 

Every feedback form just needs to inherit `FeedbackForm` and provide the `title` and `questions`. With the use of meta programming, I was able to create a simple and clean interface for creation of feedback forms which automatically set up validations and attr_accessors for use when building the forms. See `app/forms/feedback/behind_the_gems2.rb` for an example of a feedback form.

#### 2. Controller

The controller relies on `#constantize` by combining the `:form_type` param in the URL and the `FeedbackForm` namespace convention to find the form class. I did also consider using Service Locator Pattern to look up classes but I wanted even lesser code so I decided to just set a convention for the FormController to look up classes. Therefore only form objects created in `app/forms/feedback/` will work for this set up. 

#### 3. View

Since all form objects inherits `FeedbackForm`, the view code can be used for all Feedback form objects. We just need to loop through all the questions and create the input accordingly. This view only supports 2 types of input fields which from UX perspective we can consider to add more input types only if its really necessary.

The view uses [ConversationalForms](https://space10-community.github.io/conversational-form/docs/1.0.0/getting-started/), a messenger style of form filling. 

<img width="1187" alt="Screenshot 2021-09-13 at 1 07 53 AM" src="https://user-images.githubusercontent.com/10722197/132996479-991557a4-e27f-4cf9-8998-1e08d2ad9f7f.png">

#### 4. FormResponse model

This is a basic model to collect all type of form response. It only includes a `:form_type` key to identify which form does this record belongs to and also a json dump of all the responses provided by the user. I chose to use a json column type because the list of questions can be different for each form so this is a simple way to handle the response for all the different forms. 

## How does it look like? 

https://user-images.githubusercontent.com/10722197/132996973-40450a44-1a78-4119-8db3-4c7328492902.mov

## How to test?


1. `$ bin/rails db:migrate`
1. `$ bin/rails s`
1. go to http://localhost:3000/forms/behind_the_gems2
1. Try and answer the questions and submit the form
