### PR TITLE
use css grid to position company logos

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -78,10 +78,17 @@
   }
 }
 
-.row.ruby-companies {
-  display: flex;
-  justify-content: space-between;
+.ruby-companies {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-auto-rows: min-content;
+  justify-items: center;
   align-items: center;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: min-content;
+  }
 }
 
 .ruby-company {

--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -31,11 +31,10 @@
       .row
         p These Singapore companies use Ruby and they may be hiring.
       .row
-        - @supporter_companies.each_slice(4) do |companies|
-          .row.ruby-companies
-            - companies.each do |company|
-              = link_to company.website, target: '_blank', class: 'ruby-company' do
-                img.company-logo[src=company.logo_url]
+        .ruby-companies
+          - @supporter_companies.each do |company|
+            = link_to company.website, target: '_blank', class: 'ruby-company' do
+              img.company-logo[src=company.logo_url]
       .row
         p.text-center
           = link_to 'See more', companies_path, class: 'btn btn-primary btn-lg'


### PR DESCRIPTION
Currently, when the screen is small the icons go out of screen.
<img width="360" alt="Screenshot 2022-07-23 at 12 06 54 AM" src="https://user-images.githubusercontent.com/10722197/180479590-6efe9830-5147-4e33-80ed-a98dc4ddbb68.png">

Solution is to use css grid instead and make each row to only have 2 item. 

### Mobile view
<img width="360" alt="Screenshot 2022-07-23 at 12 09 55 AM" src="https://user-images.githubusercontent.com/10722197/180480138-e78cb7f0-85ef-452f-b742-e352b7e5ff0b.png">

### Desktop view
<img width="1680" alt="Screenshot 2022-07-23 at 12 10 50 AM" src="https://user-images.githubusercontent.com/10722197/180480283-a0c51f6a-b15a-4765-ac84-b1d7e97b2f22.png">


