### PR TITLE
add link to watch recordings in engineers.sg

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,10 @@ module ApplicationHelper
     "http://www.meetup.com/Singapore-Ruby-Group"
   end
 
+  def rubysg_engineerssg_link
+    "https://engineers.sg/organization/rubysg--57"
+  end
+
   def rubysg_github_guide_link
     "https://github.com/rubysg/singapore"
   end

--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -8,7 +8,10 @@
       .row
         p
           a.btn.btn-lg.btn-primary[href=rubysg_meetup_com_link target='_blank']
-            span Come Join Us!
+            span Come join us!
+          ' &nbsp;
+          a.btn.btn-lg.btn-success[href=rubysg_engineerssg_link target='_blank']
+            span Recordings
 
 .section.section-blue#chat-with-us
   .container


### PR DESCRIPTION
Add a link to help discoverability of our recordings. We should invest in keeping content updated in https://engineers.sg. 

| before | after |
| --- | --- |
|<img width="422" alt="Screenshot 2022-10-02 at 12 42 29 PM" src="https://user-images.githubusercontent.com/10722197/193438228-265390ba-e609-4317-83cb-676501196e81.png">  | <img width="422" alt="Screenshot 2022-10-02 at 12 42 33 PM" src="https://user-images.githubusercontent.com/10722197/193438231-2e0e183e-70c4-4238-9ed6-7d869fd7dfc8.png"> | 


