### PR TITLE
remove uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'pg', '~> 1' # Fix version until Rails supports 1.0.0
 
 gem 'slim-rails'
 gem 'sass-rails'
-gem 'uglifier'
 gem 'jquery-rails'
 gem 'coffee-rails'
 gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,8 +296,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     webmock (3.12.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -342,7 +340,6 @@ DEPENDENCIES
   spring-commands-rspec
   telegram-bot (~> 0.15.0)
   turbolinks
-  uglifier
   webmock
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,8 +18,7 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
### What does this PR do?

Remove Uglifier and stop configuring js_preprocessor. This is because Uglifier is causing build problems (See stacktrace below). Not too sure why do we need a js_preprocessor tbh but I checked newer RoR codebases and they do not configure js_preprocessors

Stacktrace when doing `bin/rails fly:build` before deploy. [GitHub action failed job](https://github.com/rubysg/rubysg-reboot/actions/runs/3404672067/jobs/5662175145)
```
#24 [stage-4 6/6] RUN bin/rails fly:build
#24 5.401 /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/serializers.rb:30:in `serialize': Unsupported argument type: Object (ActiveJob::SerializationError)
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:122:in `serialize_argument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:161:in `block in serialize_hash'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:160:in `each'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:160:in `each_with_object'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:160:in `serialize_hash'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:116:in `serialize_argument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:34:in `block in serialize'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:34:in `map'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/arguments.rb:34:in `serialize'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/core.rb:166:in `serialize_arguments'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/core.rb:154:in `serialize_arguments_if_needed'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/core.rb:101:in `serialize'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/queue_adapters/inline_adapter.rb:15:in `enqueue'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/enqueuing.rb:59:in `block in enqueue'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/instrumentation.rb:21:in `block in instrument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:203:in `block in instrument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:203:in `instrument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/instrumentation.rb:31:in `instrument'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/instrumentation.rb:9:in `block (2 levels) in <module:Instrumentation>'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:126:in `instance_exec'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:126:in `block in run_callbacks'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/logging.rb:22:in `block in tag_logger'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/tagged_logging.rb:99:in `block in tagged'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/tagged_logging.rb:37:in `tagged'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/tagged_logging.rb:99:in `tagged'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/logging.rb:22:in `tag_logger'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/logging.rb:14:in `block (2 levels) in <module:Logging>'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:126:in `instance_exec'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:126:in `block in run_callbacks'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:137:in `run_callbacks'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/enqueuing.rb:55:in `enqueue'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activejob-6.1.3.1/lib/active_job/configured_job.rb:16:in `perform_later'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/actionmailer-6.1.3.1/lib/action_mailer/message_delivery.rb:149:in `enqueue_delivery'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/actionmailer-6.1.3.1/lib/action_mailer/message_delivery.rb:99:in `deliver_later'
#24 5.402 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/core_ext/object/try.rb:15:in `public_send'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/core_ext/object/try.rb:15:in `try'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/runtimeerror_notifier-0.0.27/lib/runtimeerror_notifier/notifier.rb:27:in `notification'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/runtimeerror_notifier-0.0.27/lib/runtimeerror_notifier/rake_handler.rb:13:in `display_errors_with_runtimeerror'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/rake-13.0.3/lib/rake/application.rb:195:in `rescue in standard_exception_handling'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/rake-13.0.3/lib/rake/application.rb:185:in `standard_exception_handling'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/commands/rake/rake_command.rb:24:in `block in perform'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/rake-13.0.3/lib/rake/rake_module.rb:59:in `with_application'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/commands/rake/rake_command.rb:18:in `perform'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/command.rb:52:in `invoke'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/commands.rb:18:in `<top (required)>'
#24 5.403 	from bin/rails:5:in `require'
#24 5.403 	from bin/rails:5:in `<main>'
#24 5.403 /app/vendor/bundle/ruby/2.7.0/gems/uglifier-4.2.0/lib/uglifier.rb:291:in `parse_result': Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true). (Uglifier::Error)
#24 5.403 --
#24 5.403 \e[36m 11439\e[0m (function (global, factory) {
#24 5.403 \e[36m 11440\e[0m   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('@popperjs/core')) :
#24 5.403 \e[36m 11441\e[0m   typeof define === 'function' && define.amd ? define(['@popperjs/core'], factory) :
#24 5.403 \e[36m 11442\e[0m   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.bootstrap = factory(global.Popper));
#24 5.403 \e[36m 11443\e[0m })(this, (function (Popper) { 'use strict';
#24 5.403 \e[36m 11444\e[0m 
#24 5.403 \e[36m 11445\e[0m   function _interopNamespace(e) {
#24 5.403 \e[36m 11446\e[0m     if (e && e.__esModule) return e;
#24 5.403 \e[91m    => \e[0m    \e[91mconst n = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } });\e[0m
#24 5.403 \e[36m 11448\e[0m     if (e) {
#24 5.403 \e[36m 11449\e[0m       for (const k in e) {
#24 5.403 \e[36m 11450\e[0m         if (k !== 'default') {
#24 5.403 \e[36m 11451\e[0m           const d = Object.getOwnPropertyDescriptor(e, k);
#24 5.403 \e[36m 11452\e[0m           Object.defineProperty(n, k, d.get ? d : {
#24 5.403 \e[36m 11453\e[0m             enumerable: true,
#24 5.403 \e[36m 11454\e[0m             get: () => e[k]
#24 5.403 \e[36m 11455\e[0m           });
#24 5.403 ==
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/uglifier-4.2.0/lib/uglifier.rb:221:in `run_uglifyjs'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/uglifier-4.2.0/lib/uglifier.rb:176:in `compile_with_map'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/uglifier_compressor.rb:58:in `call'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/uglifier_compressor.rb:30:in `call'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:84:in `call_processor'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:66:in `block in call_processors'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:65:in `reverse_each'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:65:in `call_processors'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:182:in `load_from_unloaded'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:59:in `block in load'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:337:in `fetch_asset_from_dependency_cache'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:43:in `load'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/cached_environment.rb:44:in `load'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/bundle.rb:32:in `block in call'
#24 5.403 	from /usr/lib/fullstaq-ruby/versions/2.7.1-jemalloc/lib/ruby/2.7.0/set.rb:328:in `each_key'
#24 5.403 	from /usr/lib/fullstaq-ruby/versions/2.7.1-jemalloc/lib/ruby/2.7.0/set.rb:328:in `each'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/bundle.rb:31:in `call'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:84:in `call_processor'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:66:in `block in call_processors'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:65:in `reverse_each'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/processor_utils.rb:65:in `call_processors'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:182:in `load_from_unloaded'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:59:in `block in load'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:337:in `fetch_asset_from_dependency_cache'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/loader.rb:43:in `load'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/cached_environment.rb:44:in `load'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/base.rb:81:in `find_asset'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/base.rb:88:in `find_all_linked_assets'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.2/lib/sprockets/manifest.rb:125:in `block (2 levels) in find'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:24:in `block in execute'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `block in synchronize'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:19:in `execute'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/promise.rb:563:in `block in realize'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:363:in `run_task'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:352:in `block (3 levels) in create_worker'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `loop'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `block (2 levels) in create_worker'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `catch'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `block in create_worker'
#24 5.406 E, [2022-11-06T14:31:21.502510 #1] ERROR -- : [ActiveJob] Failed enqueuing ActionMailer::DeliveryJob to Inline(mailers): ActiveJob::SerializationError (Unsupported argument type: Object)
#24 ERROR: executor failed running [/bin/bash -c bin/rails fly:build]: exit code: 1
------
 > [stage-4 6/6] RUN bin/rails fly:build:
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:19:in `execute'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/promise.rb:563:in `block in realize'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:363:in `run_task'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:352:in `block (3 levels) in create_worker'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `loop'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `block (2 levels) in create_worker'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `catch'
#24 5.403 	from /app/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.8/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `block in create_worker'
#24 5.406 E, [2022-11-06T14:31:21.502510 #1] ERROR -- : [ActiveJob] Failed enqueuing ActionMailer::DeliveryJob to Inline(mailers): ActiveJob::SerializationError (Unsupported argument type: Object)
------
```

### What should reviewer's focus on?

Is removing js_preprocessor the correct fix?