### PR TITLE
add link to photo album

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,8 @@ module ApplicationHelper
   def rubysg_github_guide_link
     "https://github.com/rubysg/singapore"
   end
+
+  def rubysg_photo_album_link
+    "https://www.icloud.com/sharedalbum/#B0SJtdOXmmrrha"
+  end
 end

--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -8,6 +8,10 @@
       ' &nbsp;
       a.btn.btn-custom.btn-custom-success[href=rubysg_engineerssg_link target='_blank']
         span Recordings
+      ' &nbsp;
+      a.btn.btn-custom.btn-custom-success[href=rubysg_photo_album_link target='_blank']
+        span Photos
+      ' &nbsp;
 
 .section.section-blue
   .container-md.col-md-7


### PR DESCRIPTION
Collect photo into an icloud album because it's easy for me to new photos for folks with iPhone. So far, 2/3 of the organisers use iPhone so its a balance. We can migrate to another photo hosting service if a better one comes up.

<img width="779" alt="Screenshot 2022-11-09 at 11 48 29 PM" src="https://user-images.githubusercontent.com/10722197/200876548-785067fc-5c6b-4171-933b-6cc05bd47f8b.png">
