### PR TITLE
Update GH action pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/deploy_to_fly.yml
+++ b/.github/workflows/deploy_to_fly.yml
@@ -6,6 +6,36 @@ on:
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports: ['5432:5432']
+        options:
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+      - name: Setup environment and run tests
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+          RAILS_ENV: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        run: |
+          bundle install
+          bundle exec rails db:create db:migrate
+          bundle exec rspec spec
   deploy:
       name: Deploy app
       runs-on: ubuntu-latest


### PR DESCRIPTION

We are running `ci.yml` and `deploy_to_fly.yml` after every merge. Instead of doing this which doesn't block deploy when CI fails, 
1. stop running `ci.yml` after merge
2. start running tests into `deploy_to_fly.yml`

![image](https://github.com/rubysg/rubysg-reboot/assets/10722197/3171497f-acd6-43b9-b942-dc5a0d02b7d9)
