### PR TITLE
add PingJob to see if keeping the app alive ensures RubyWeekly messages get sent

### DIFF
--- a/app/jobs/ping_job.rb
+++ b/app/jobs/ping_job.rb
@@ -1,0 +1,20 @@
+class PingJob < ApplicationJob
+  queue_as :default
+
+  discard_on StandardError
+
+  def perform(url)
+    response = HTTParty.get(url)
+
+    if ENV["BOB_OPS_RUBYSG_ORGANISER_INCOMING_WEBHOOK_KEY"].presence
+      HTTParty.post(
+        "https://bobops.net/api/incoming_webhook",
+        body: { "text" => "Ping #{url}, Status: #{response.code}" }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "Authorization" => "Bearer #{ENV["BOB_OPS_RUBYSG_ORGANISER_INCOMING_WEBHOOK_KEY"]}"
+        }
+      )
+    end
+  end
+end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -10,3 +10,9 @@ s.cron '30 17 * * 5' do
     SendWeeklyUpdatesJob.perform_later(sub.chat_id)
   end
 end
+
+# Ping the website 2 times a day to stop fly.io from letting it go to sleep because the web instance is currently
+# hosting the scheduler, and we need the scheduler to be running!
+s.cron '0 0,12 * * *' do
+  PingJob.perform_later("https://ruby.sg")
+end


### PR DESCRIPTION
RubySgBot hasn't been very consistent in pushing the RubyWeekly articles to the RubySG telegram group every friday..

I'm wondering if fly.io is putting the application to sleep because of the extremely low traffic for https://ruby.sg which results in the scheduler not running because it is hosted on the web instance. So I'm scheduling a ping job at 12am and 12pm to see if I can keep the app alive until tomorrow and see if the RubyWeekly articles get sent. 