### PR TITLE
update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/deploy_to_fly.yml
+++ b/.github/workflows/deploy_to_fly.yml
@@ -21,7 +21,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/hourly_ping.yml
+++ b/.github/workflows/hourly_ping.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Call API
       run: curl https://ruby.sg/


### PR DESCRIPTION
versions before `actions/checkout@v4` uses node 16 which is outdated. updating to v4 will have the actions itself use node 20. this should not break anything