### PR TITLE
update rubysg telegram link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
   end
 
   def rubysg_telegram_link
-    "https://t.me/+d8P2epgIohMwNDE1"
+    "https://t.me/+2SjusiYG07pjYWE1"
   end
 
   def rubysg_meetup_com_link


### PR DESCRIPTION
Seems like bots have caught on to our telegram group link on the website. Revoked the old link and updating to a new link. 